### PR TITLE
Add search bar on exercise List and add tag filtering

### DIFF
--- a/fitvoxbackend/Fitvox/views.py
+++ b/fitvoxbackend/Fitvox/views.py
@@ -30,7 +30,8 @@ def signup(request):
         for exercise in ExerciseDefault.objects.all():
             new_exercise_per_user = ExercisePerUser(user=created_user, muscleType=exercise.muscleType,
                                                     exerciseType=exercise.exerciseType, name=exercise.name,
-                                                    hardness=exercise.hardness, isFavorite=False, volumes={}, oneRMs={})
+                                                    hardness=exercise.hardness, tags={'tags':exercise.tags["tags"]},
+                                                    isFavorite=False, volumes={}, oneRMs={}, )
             new_exercise_per_user.save()
 
         return HttpResponse(status=201)

--- a/fitvoxfrontend/src/containers/ExerciseList/ExerciseList.js
+++ b/fitvoxfrontend/src/containers/ExerciseList/ExerciseList.js
@@ -14,17 +14,21 @@ class ExerciseList extends Component {
         exerciseType_selected: false,
         muscleType: null,
         exerciseType: null,
-        tags: null
+        tags: [],
+        tag: "#",
+        query: [], 
     }
 
     onMuscleTypeClick(muscleType) {
         this.setState({muscleType_selected: true})
         this.setState({muscleType: muscleType})
+        this.setState({query: [...this.state.query, muscleType]})
     }
 
     onExerciseTypeClick(exerciseType) {
         this.setState({exerciseType_selected: true})
         this.setState({exerciseType: exerciseType})
+        this.setState({query: [...this.state.query, exerciseType]})
     }
 
     onExerciseEntryClick = (name)=>{
@@ -37,11 +41,54 @@ class ExerciseList extends Component {
         this.setState({muscleType: null})
         this.setState({exerciseType_selected: false})
         this.setState({exerciseType: null})
+        this.setState({query: []})
     }
 
     onGoBackExerciseType = () => {
         this.setState({exerciseType_selected: false})
         this.setState({exerciseType: null})
+        this.setState({query: [this.state.query[0]]})
+    }
+
+    onSearchTagHandler = () => {
+        let input_tag = this.state.tag;
+        this.setState({query:[...this.state.query, input_tag], tag: "#", tags:[...this.state.tags, input_tag]})
+    }
+
+    searchBar = () => {
+        let add_tag_button = null;
+        if (this.state.exerciseType_selected){
+            add_tag_button = (<button id="search-with-tag"
+                style = {{width: '5%', height: 100}}
+                onClick = {()=>this.onSearchTagHandler()}>
+                    Add Tag
+            </button>)
+        }
+        return (
+            <div className = "SearchBar" align = "center">
+                <div>
+                    <h1>SearchBar</h1>
+                    <input
+                        id = "search-bar"
+                        value = {this.state.query}
+                        style={{ width: '30%', height: 50 }}
+                        //onChange={(event)=>this.setState({query: [...this.state.query, event.target.value]})}
+                    />
+                </div>
+                <div>
+                    <h1>Type Tag to search</h1>
+                    <div>
+                        <textarea
+                            id = "tag-bar"
+                            value = {this.state.tag}
+                            style={{ width: '30%', height: 100 }}
+                            onChange = {(event)=>this.setState({tag: event.target.value})}
+                        />
+                        {add_tag_button}
+                    </div>
+                </div>
+            </div>
+        )
     }
 
     render() {
@@ -55,6 +102,7 @@ class ExerciseList extends Component {
             }
             return (
                 <div>
+                    {this.searchBar()}
                     <h1>Select Muscle Type</h1>
                     <div>{muscleTypeIcons}</div>
                 </div>
@@ -74,6 +122,7 @@ class ExerciseList extends Component {
 
             return (
                 <div>
+                    {this.searchBar()}
                     <h1>Select Exercise Type</h1>
                     <h2>Selected Muscle Type: {this.state.muscleType}</h2>
                     <div>
@@ -91,26 +140,45 @@ class ExerciseList extends Component {
                     exercise['exerciseType']===this.state.exerciseType)
                     //  && exercise['hardness'].indexOf(this.state.hardness)!==-1
                     {
-                        const name = exercise['name']
-                        exerciseEntries.push(<ExerciseEntry name={name}
-                                                                 onClick={() => this.onExerciseEntryClick(name)}/>)
+                        if (this.state.tags.length === 0){
+                            const name = exercise['name']
+                            exerciseEntries.push(<ExerciseEntry name={name}
+                                                                onClick={() => this.onExerciseEntryClick(name)}/>)
+                        }
+                        else {
+                            let flag = true;
+                            for (let tag of this.state.tags){
+                                if (!exercise["tags"]["tags"].includes(tag)) {
+                                    flag = false;
+                                    break;
+                                }
+                            }
+                            if (flag){
+                                const name = exercise['name']
+                                exerciseEntries.push(<ExerciseEntry name={name}
+                                                                    onClick={() => this.onExerciseEntryClick(name)}/>)
+                            }
+                        }
                     }
                 }
             }
 
             return (
                 <div>
+                    {this.searchBar()}
                     <h2>Selected Muscle Type: {this.state.muscleType}</h2>
                     <h2>Selected Exercise Type: {this.state.exerciseType}</h2>
                     <div>
                         <button onClick={() => this.onGoBackMuscleType()}>Select Muscle Type again</button>
                         <button onClick={()=>this.onGoBackExerciseType()}>Select Exercise Type again</button>
                     </div>
-                    <div>
-                        <h2>Add tags</h2>
-                        <input type="text"/>
-                        <button>Add</button>
-                    </div>
+                    {
+                    //<div>
+                    //    <h2>Add tags</h2>
+                    //    <input type="text"/>
+                    //    <button>Add</button>
+                    //</div>
+                    }
                     <div>
                         {exerciseEntries}
                     </div>


### PR DESCRIPTION
tag 저장을 위해 tags: []로 설정했으며, 초기 design된 UI에 맞추기 위해 선택된 항목들을 저장하는 query: []를 state에 추가했습니다. 그리고  tag입력창에 기본적으로 "#"을 띄워놓기 위해 tag: "#" 또한 추가했습니다

tag 입력 창 옆의 add tag 버튼은 this.state.exerciseType_selected가 true일 때만 나타나도록 했으며,
search bar 자체는 onChange 가 없는 입력창으로 설정해 두었습니다.

그리고 초기 tag 설정을 위해 views.py에서 signup 과정에 exercise per user의 tags를 exercise default의 tags를 그대로 불러와 넣어주는 형식으로 바꿨습니다. 만약 이 방법이 계속 사용된다면 db에서 user들을 다 지우고 다시 만드는 과정이 있으면 좋을 것 같습니다.